### PR TITLE
fix: 4 space indented demo code was rendered as new <code> tag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,9 +52,20 @@ module.exports = (options = {}) => {
         const language = (info.split(demoCodeMark)[1] || 'vue').trim()
 
         for (let index = idx; index < tokens.length; index++) {
-            const { map, type, content } = tokens[index]
-
+            const { map, type } = tokens[index]
             if (type === END_TYPE) break
+
+            let { content } = tokens[index]
+
+            // this means users use 4 space to indent the demo code,
+            // which shouldn't be interpreted as another new <code>
+            if (type === 'code_block') {
+                const indent = ' '.repeat(4)
+                content = `${indent}${content.replace('\n', `\n${indent}`)}`
+            }
+
+            // consider every token as html_block to render as raw string, instead of markdown text
+            tokens[index].type = 'html_block'
 
             // add empty lines
             if (map) {


### PR DESCRIPTION
目前存在以下问题：当我在文档里输入如下文本时：
```
::: demo
<container>
    <child />
</container>
:::
```
代码既无法按原排版渲染（即第四行缩进4格），也无法渲染出组件的 DOM。这是因为 markdownIt 在解析上述文本时把第二行当成 markdown 语法里的 code 语法了。我想可以通过在 markdown-it-container 的 render 里强制改动 token 的类型来规避上述问题