### PR TITLE
feat: support jsfiddle framework API parameter

### DIFF
--- a/src/DemoAndCode.vue
+++ b/src/DemoAndCode.vue
@@ -109,8 +109,9 @@ export default {
             const jsLibs = parseAndDecode(vm.jsLibsStr)
             const cssLibs = parseAndDecode(vm.cssLibsStr)
             const codesandboxOptions = parseAndDecode(vm.codesandboxStr)
+            const jsfiddleOptions = parseAndDecode(vm.jsfiddleStr)
 
-            return { js, css, html, jsLibs, cssLibs, codesandboxOptions }
+            return { js, css, html, jsLibs, cssLibs, codesandboxOptions, jsfiddleOptions }
         },
     },
     methods: {

--- a/src/OnlineEdit.vue
+++ b/src/OnlineEdit.vue
@@ -72,11 +72,17 @@ export default {
         cssLibs: { type: Array, default: () => [] },
         editors: { type: String, default: '101' },
         codesandboxOptions: { type: Object, default: () => ({}) },
+        jsfiddleOptions: { type: Object, default: () => ({}) },
     },
     computed: {
         jsTmpl: vm => getJsTmpl(vm.js),
         htmlTmpl: vm => getHtmlTmpl(vm.html),
-        actionUrl: vm => ACTION_MAP[vm.platform],
+        actionUrl: vm => {
+            if (vm.platform === 'jsfiddle'){
+                return ACTION_MAP[vm.platform] + vm.jsfiddleOptions.framework;
+            }
+            return ACTION_MAP[vm.platform];
+        },
         resources: vm => vm.jsLibsWithVue.concat(vm.cssLibs).join(','),
         js_external: vm => vm.jsLibsWithVue.join(';'),
         platformTip: vm => PLATFORM_TIP_MAP[vm.platform],

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,7 +6,7 @@ const PLATFORMS = ['codepen', 'jsfiddle', 'codesandbox']
 
 const ACTION_MAP = {
     codepen: 'https://codepen.io/pen/define',
-    jsfiddle: 'https://jsfiddle.net/api/post/library/pure',
+    jsfiddle: 'https://jsfiddle.net/api/post/',
     codesandbox: 'https://codesandbox.io/api/v1/sandboxes/define',
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,12 @@ const defaults = {
         jsfiddle: true,
         codesandbox: true,
     },
+
+    // https://docs.jsfiddle.net/api/display-a-fiddle-from-post
+    jsfiddle: {
+        framework: "library/pure",
+    },
+
     // https://codesandbox.io/docs/importing#define-api
     codesandbox: {
         deps: {}, // dependencies
@@ -80,11 +86,13 @@ module.exports = (options = {}) => {
 
         const onlineBtns = Object.assign({}, defaults.onlineBtns, options.onlineBtns)
         const codesandbox = Object.assign({}, defaults.codesandbox, options.codesandbox)
+        const jsfiddle = Object.assign({}, defaults.jsfiddle, options.jsfiddle)
 
         const jsLibsStr = encodeAndStringify(jsLibs)
         const cssLibsStr = encodeAndStringify(cssLibs)
         const onlineBtnsStr = encodeAndStringify(onlineBtns)
         const codesandboxStr = encodeAndStringify(codesandbox)
+        const jsfiddleStr = encodeAndStringify(jsfiddle)
 
         return `
             <DemoAndCode
@@ -97,6 +105,7 @@ module.exports = (options = {}) => {
                 :minHeight="${minHeight}"
                 onlineBtnsStr="${onlineBtnsStr}"
                 codesandboxStr="${codesandboxStr}"
+                jsfiddleStr="${jsfiddleStr}"
             >
                 <template slot="demo">
         `


### PR DESCRIPTION
JSFiddle has a parameter where you can specify if your code is plain or uses a framework. This is useful if you'd like to use Vue for example.

I've added the ability to specify the framework via the config parameters, for example:

```js
module.exports = {
    plugins: [
        ['demo-code', {
            jsLibs: [
                // umd
                'https://unpkg.com/tua-storage/dist/TuaStorage.umd.js',
            ],
            cssLibs: [
                'https://unpkg.com/animate.css@3.7.0/animate.min.css',
            ],
            showText: 'show code',
            hideText: 'hide',
            styleStr: 'text-decoration: underline;',
            minHeight: 200,
            onlineBtns: {
                codepen: true,
                jsfiddle: true,
                codesandbox: true,
            },
            codesandbox: {
                deps: { 'lodash': 'latest' },
                json: '',
                query: '',
                embed: '',
            },
            jsfiddle: {
                framework: "library/pure", // default
                // framework: "vue/2.6.11",
            },
            demoCodeMark: 'demo-code',
            copyOptions: { ... },
        }]
    ],
}
```